### PR TITLE
stepLength -> step_length in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ properties:
 >
 > It is recommended to use the `STALKER` macro to declare the effect itself.
 
-### `.stepLength`
+### `.step_length`
 
 > The length - in milliseconds - of each step of the animation. An animation
 > lasts 256 steps.


### PR DESCRIPTION
There is a typo in the README.md file.