### PR TITLE
Add Rainbow stalker effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ The plugin provides the following effects:
 
 > A blazing trail of fire will follow our fingers!
 
+### `Rainbow()`
+
+> Leave a rainbow behind, where your fingers has been!
+
 ## Dependencies
 
 * [Kaleidoscope-LEDControl](https://github.com/keyboardio/Kaleidoscope-LEDControl)

--- a/src/Kaleidoscope/LED-Stalker.cpp
+++ b/src/Kaleidoscope/LED-Stalker.cpp
@@ -127,6 +127,19 @@ cRGB BlazingTrail::compute(uint8_t *step) {
   return color;
 }
 
+// Rainbow
+Rainbow::Rainbow(void) {
+}
+
+cRGB Rainbow::compute(uint8_t *step) {
+  if (*step > 0)
+    *step -= 1;
+  else
+    *step = 0;
+
+  return hsvToRgb(255 - *step, 255, *step);
+}
+
 }
 
 }

--- a/src/Kaleidoscope/LED-Stalker.h
+++ b/src/Kaleidoscope/LED-Stalker.h
@@ -67,6 +67,13 @@ class BlazingTrail : public StalkerEffect::ColorComputer {
   cRGB compute(uint8_t *step) final;
 };
 
+class Rainbow : public StalkerEffect::ColorComputer {
+ public:
+  Rainbow(void);
+
+  cRGB compute(uint8_t *step) final;
+};
+
 }
 }
 


### PR DESCRIPTION
There already exist 2 rainbow LED effects, this adds a third, using
the LED-Stalker effect.

When you press a key, the LED on that key will cycle through all the
colors of the rainbow, independent of the colors of other keys.