### PR TITLE
Add inactive_color property

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ properties:
 >
 > Defaults to 50.
 
+### `.inactive-color`
+
+> The color to use when a key hasn't been pressed recently.
+>
+> Defaults to `(cRGB) { 0, 0, 0 }`
+
 ## Plugin helpers
 
 ### `STALKER(effect, params)`

--- a/src/Kaleidoscope/LED-Stalker.cpp
+++ b/src/Kaleidoscope/LED-Stalker.cpp
@@ -24,6 +24,9 @@ uint8_t StalkerEffect::map_[ROWS][COLS];
 StalkerEffect::ColorComputer *StalkerEffect::variant;
 uint16_t StalkerEffect::step_length = 50;
 uint16_t StalkerEffect::step_start_time_;
+cRGB StalkerEffect::inactive_color = (cRGB) {
+  0, 0, 0
+};
 
 void StalkerEffect::onActivate(void) {
   memset(map_, 0, sizeof(map_));
@@ -59,9 +62,7 @@ void StalkerEffect::update(void) {
       }
 
       if (!map_[r][c])
-        ::LEDControl.setCrgbAt(r, c, (cRGB) {
-        0, 0, 0
-      });
+        ::LEDControl.setCrgbAt(r, c, inactive_color);
     }
   }
 

--- a/src/Kaleidoscope/LED-Stalker.h
+++ b/src/Kaleidoscope/LED-Stalker.h
@@ -34,6 +34,7 @@ class StalkerEffect : public LEDMode {
 
   static ColorComputer *variant;
   static uint16_t step_length;
+  static cRGB inactive_color;
 
   EventHandlerResult onKeyswitchEvent(Key &mapped_key, byte row, byte col, uint8_t keyState);
 


### PR DESCRIPTION
This makes it so that `StalkerEffect.inactive_color = ...` can be used to set the color used for keys that haven't been pressed recently.  Here's what the usage of this looks like in my config:

```
  StalkerEffect.variant = STALKER(BlazingTrail);
  StalkerEffect.step_length = 200;
  StalkerEffect.inactive_color = (cRGB) { 255, 0, 0 };
```